### PR TITLE
Log at debug level to not overload each analysis log if FPGA Metrics …

### DIFF
--- a/sonar-fpga-metrics-plugin/src/main/java/com/lintyservices/sonar/plugins/fpgametrics/sensor/MeasuresImporter.java
+++ b/sonar-fpga-metrics-plugin/src/main/java/com/lintyservices/sonar/plugins/fpgametrics/sensor/MeasuresImporter.java
@@ -70,7 +70,7 @@ public class MeasuresImporter implements ProjectSensor {
     try {
       return new Gson().fromJson(new FileReader(filePath), Map.class);
     } catch (FileNotFoundException e) {
-      LOG.info("[FPGA Metrics] No measures report found: " + filePath);
+      LOG.debug("[FPGA Metrics] No measures report found: " + filePath);
       return Collections.emptyMap();
     } catch (JsonSyntaxException | JsonIOException e) {
       throw new IllegalStateException("[FPGA Metrics] Cannot parse JSON measures report: " + filePath);


### PR DESCRIPTION
…plugin is not used