### PR TITLE
Run build on Windows on master branch only

### DIFF
--- a/.github/workflows/full-ci-cd.yml
+++ b/.github/workflows/full-ci-cd.yml
@@ -36,6 +36,7 @@ jobs:
         run: mvn -B versions:set -DnewVersion=${{ github.event.inputs.release_version }} -DgenerateBackupPoms=false
 
       - name: Build and Test against SonarQube ${{ matrix.sonarqube }}
+        if: contains(github.ref, 'master') || matrix.os == 'ubuntu-latest'
         run: mvn -B clean verify -Pits -"Dsonar.runtimeVersion=${{ matrix.sonarqube }}"
 
       - name: Run SonarQube Analysis


### PR DESCRIPTION
Run CI/CD on Windows only on master branch to reduce costs.
Running on master branch only for Windows is enough.